### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [English Version](https://github.com/foss4good/end)
 
-##End的定位
+## End的定位
 安全、高性能的实时数据框架  
 不会像meteor一样提供前后端统一的框架,End只关注实时数据。
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
